### PR TITLE
fix issue with not exist constants in reader

### DIFF
--- a/library/DrSlump/Protobuf/Codec/Binary/Reader.php
+++ b/library/DrSlump/Protobuf/Codec/Binary/Reader.php
@@ -121,7 +121,7 @@ class Reader
     public function sFixed32()
     {
         $bytes = $this->read(4);
-        if ($this->isBigEndian() === self::BIG_ENDIAN) {
+        if ($this->isBigEndian()) {
             $bytes = strrev($bytes);
         }
 
@@ -179,7 +179,7 @@ class Reader
     public function float()
     {
         $bytes = $this->read(4);
-        if ($this->isBigEndian() === self::BIG_ENDIAN) {
+        if ($this->isBigEndian()) {
             $bytes = strrev($bytes);
         }
 


### PR DESCRIPTION
fix issue with not exist constants in reader
