### PR TITLE
Fixing issue with "repeated" item that is not inside an array

### DIFF
--- a/library/DrSlump/Protobuf/Codec/Binary.php
+++ b/library/DrSlump/Protobuf/Codec/Binary.php
@@ -109,6 +109,9 @@ class Binary implements Protobuf\CodecInterface
                     $writer->varint(strlen($data));
                     $writer->write($data);
                 } else {
+                    
+                    // Make sure the value is an array of values
+                    $value = is_array($value) ? $value : array($value);
                     foreach($value as $val) {
                         // Skip nullified repeated values
                         if (NULL === $val) {


### PR DESCRIPTION
I've had a problem trying this simple example:

message.proto

<pre>
package test;

message Person {
  required string name = 1;
  required int32 id = 2;
  optional string email = 3;

  enum PhoneType {
    MOBILE = 0;
    HOME = 1;
    WORK = 2;
  }

  message PhoneNumber {
    required string number = 1;
    optional PhoneType type = 2 [default = HOME];
  }

  repeated PhoneNumber phone = 4;
}
</pre>


with this code:

``` php

<?php

  require_once 'DrSlump/Protobuf.php';                                         
  \DrSlump\Protobuf::autoload();

  require_once 'generated-code/message.php';                                   

  use \test\Person, \test\Person\PhoneNumber;                                  

  $p = new Person();                                                           

  $p->setName('Foo');                                                       
  $p->setId(2048);
  $p->setEmail('foo@bar.com');                                          

  $phoneNumber = new PhoneNumber;                                              
  $phoneNumber->setNumber('+8888888888');                                     
  $p->setPhone($phoneNumber);                                                  

  $data = $p->serialize();                                                                                                                                    
  var_dump($data);
```

was giving me a fatal error because the recursive call encodeMessage was expecting a Message object and was receiving a field of the Object that was being iterated over instead of the array that should contain it
