### PR TITLE
Problem serializing fields assigned "false" with PHPArray

### DIFF
--- a/library/DrSlump/Protobuf/Codec/PhpArray.php
+++ b/library/DrSlump/Protobuf/Codec/PhpArray.php
@@ -133,7 +133,7 @@ class PhpArray implements Protobuf\CodecInterface
                     return $this->decodeMessage(new $nested, $value);
                 }
             case Protobuf::TYPE_BOOL:
-                return filter_var($value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
+                return !!$value;
             case Protobuf::TYPE_STRING:
             case Protobuf::TYPE_BYTES:
                 return (string)$value;


### PR DESCRIPTION
Due to a weird behavior of filter_var, variables assigned correctly to "false" were being serialized as NULL.

``` php
<?php

$value = 0;
filter_var($value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE)); 
# RETURNS FALSE

$value = false;
var_dump(filter_var($value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE)); 
#RETURNS NULL
```

So the solution would be replace, in PHPArray.php:136:

``` php
  case Protobuf::TYPE_BOOL:
-                return filter_var($value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
+                return !!$value;
```
