### PR TITLE
Add support for underscores in names

### DIFF
--- a/library/DrSlump/Protobuf/Compiler.php
+++ b/library/DrSlump/Protobuf/Compiler.php
@@ -92,7 +92,7 @@ class Compiler
     public function camelize($name)
     {
         return preg_replace_callback(
-                    '/_([a-z0-9])/i',
+                    '/_([a-z0-9_])/i',
                     function($m){ return strtoupper($m[1]); },
                     $name
                  );


### PR DESCRIPTION
We have fields that start with underscore that get mangled during code generation.
