### PR TITLE
Added isMessage to make parsing nested message structures cleaner

### DIFF
--- a/library/DrSlump/Protobuf/Field.php
+++ b/library/DrSlump/Protobuf/Field.php
@@ -83,4 +83,9 @@ class Field
     {
         return $this->extension;
     }
+    
+    public function isMessage()
+    {
+        return $this->type === Protobuf::TYPE_MESSAGE;
+    }
 }


### PR DESCRIPTION
Other types are less important, this being PHP and all, but knowing if the content of a field is a Message is valuable for parsing nested message structures.

Obviously this isn't necessary, but it turns

``` php
$field->getType() === \DrSlump\Protobuf::TYPE_MESSAGE
```

into

``` php
$field->isMessage()
```

which is nice
