### PR TITLE
Make composer.json Packagist compatible

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "DrSlump/Protobuf-PHP",
+    "name": "dr-slump/protobuf-php",
     "description": "PHP implementation of Google's Protocol Buffers",
     "keywords": ["protobuf", "protocol buffer", "serializing"],
     "homepage": "https://github.com/drslump/Protobuf-PHP",


### PR DESCRIPTION
I tried adding this package to Packagist so there will be a package tracking the official repo (instead of forks), but the package name contains uppercase letters which is not allowed by Packagist:

> The package name DrSlump/Protobuf-PHP is invalid, it should not contain uppercase characters. We suggest using dr-slump/protobuf-php instead.
