### PR TITLE
Update composer.json to fit packagist conventions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,10 +18,5 @@
     },
     "autoload": {
         "psr-0": {"DrSlump": "library/"}
-    },
-    "extra": {
-        "branch-alias": {
-            "dev-master": "1.0"
-        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "DrSlump/Protobuf-PHP",
+    "name": "dr-slump/protobuf-php",
     "description": "PHP implementation of Google's Protocol Buffers",
     "keywords": ["protobuf", "protocol buffer", "serializing"],
     "homepage": "https://github.com/drslump/Protobuf-PHP",


### PR DESCRIPTION
Adding this package to a new packagist instance results in the error: 

The package name DrSlump/Protobuf-PHP is invalid, it should not contain uppercase characters. We suggest using dr-slump/protobuf-php instead.

I'm guessing this rule was added after this package was already on the central packagist server, but it prevents in house packagists from adding this package now.
