### PR TITLE
Fix PhpGenerator.php output

### DIFF
--- a/library/DrSlump/Protobuf/Compiler/PhpGenerator.php
+++ b/library/DrSlump/Protobuf/Compiler/PhpGenerator.php
@@ -220,6 +220,8 @@ class PhpGenerator extends AbstractGenerator
 
         $s[]= '    /** @var \Closure[] */';
         $s[]= '    protected static $__extensions = array();';
+        $s[]= '    /** @var \DrSlump\Protobuf\Descriptor */';
+        $s[]= '    static protected $__descriptor;';
         $s[]= '';
         $s[]= '    public static function descriptor()';
         $s[]= '    {';
@@ -314,8 +316,8 @@ class PhpGenerator extends AbstractGenerator
         $s[]= '$f = new \DrSlump\Protobuf\Field();';
         $s[]= '$f->number    = ' . $field->getNumber() . ';';
         $s[]= '$f->name      = "'. $field->getName() . '";';
-        $s[]= '$f->type      = \DrSlump\Protobuf::TYPE_' . $type . ';';
-        $s[]= '$f->rule      = \DrSlump\Protobuf::RULE_' . $rule . ';';
+        $s[]= '$f->type      = \DrSlump\Protobuf\Protobuf::TYPE_' . $type . ';';
+        $s[]= '$f->rule      = \DrSlump\Protobuf\Protobuf::RULE_' . $rule . ';';
 
         if ($field->hasTypeName()):
         $ref = $field->getTypeName();


### PR DESCRIPTION
```
add $__descriptor static var
update incorrect references to DrSlump\Protobuf\Protobuf
these changes line up PhpGenerator.php output with the PHP message template
```
