### PR TITLE
If a submessage has 0 length, don't try to decode it.

### DIFF
--- a/library/DrSlump/Protobuf/Codec/Binary.php
+++ b/library/DrSlump/Protobuf/Codec/Binary.php
@@ -266,7 +266,11 @@ class Binary implements Protobuf\CodecInterface
                     $submessage = new $submessage;
 
                     $len = $reader->varint();
-                    $value = $this->decodeMessage($reader, $submessage, $len);
+                    if ($len) {
+                       $value = $this->decodeMessage($reader, $submessage, $len);
+                    } else {
+                       $value = $submessage;
+                    }
                 } else {
                     $value = $this->decodeSimpleType($reader, $type, $wire);
                 }


### PR DESCRIPTION
This prevents the decoder from thinking the next fields in the parent
message are a part of the submessage.
