### PR TITLE
Update PhpArray.php

### DIFF
--- a/library/DrSlump/Protobuf/Codec/PhpArray.php
+++ b/library/DrSlump/Protobuf/Codec/PhpArray.php
@@ -143,6 +143,12 @@ class PhpArray implements Protobuf\CodecInterface
             case Protobuf::TYPE_FLOAT:
             case Protobuf::TYPE_DOUBLE:
                 return filter_var($value, FILTER_VALIDATE_FLOAT, FILTER_NULL_ON_FAILURE);
+            case Protobuf::TYPE_ENUM:
+                $nested = $field->getReference();
+                $reference = new $nested;
+                if (!is_null($ref_value = $reference->__get($value)))
+                    $value = $ref_value;
+                return filter_var($value, FILTER_VALIDATE_INT, FILTER_NULL_ON_FAILURE);
             // Assume the rest are ints
             default:
                 return filter_var($value, FILTER_VALIDATE_INT, FILTER_NULL_ON_FAILURE);


### PR DESCRIPTION
If enum value specified as string instead of integer, it will be converted to int using referenced Enum constants
